### PR TITLE
fix: update clientId regex to match new JS config format

### DIFF
--- a/src/WealthsimpleAPIBase.php
+++ b/src/WealthsimpleAPIBase.php
@@ -136,7 +136,7 @@ abstract class WealthsimpleAPIBase
             }
             $response = $this->sendGET($app_js_url);
             foreach (explode("\n", $response) as $line) {
-                if (preg_match('/production.*clientId:"([a-f0-9]+)"/i', $line, $re)) {
+                if (preg_match('/"production"[^}]*clientId:"([a-f0-9]+)"/i', $line, $re)) {
                     $this->session->client_id = $re[1];
                 }
             }


### PR DESCRIPTION
Wealthsimple's app JS changed the production config structure from `production:{...,clientId:"..."}` to `{env:"production",clientId:"..."}`, breaking the regex used to extract the OAuth client ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth session initialization for improved reliability in credential extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gboudreau/ws-api-php/pull/5?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->